### PR TITLE
Add remote node support

### DIFF
--- a/canbus/canlink.py
+++ b/canbus/canlink.py
@@ -392,7 +392,7 @@ class CanLink(LinkLayer):
             #    Remap the mti
             header = 0x19_000_000 | ((msg.mti.value & 0xFFF) << 12)
 
-            alias = self.nodeIdToAlias[msg.source]
+            alias = self.nodeIdToAlias.get(msg.source)
             if alias is not None:  # might not know it if error
                 header |= (alias & 0xFFF)
             else:
@@ -404,7 +404,7 @@ class CanLink(LinkLayer):
                 destt = msg.destination
                 if destt is None:
                     destt = NodeID(0)
-                alias = self.nodeIdToAlias[destt]
+                alias = self.nodeIdToAlias.get(destt)
                 if alias is not None:  # might not know it?
                     #    address and have alias, break up data
                     dataSegments = self.segmentAddressedDataArray(alias,

--- a/example_node_implementation.py
+++ b/example_node_implementation.py
@@ -14,16 +14,9 @@ from canbus.tcpsocket import TcpSocket
 from canbus.canphysicallayergridconnect import CanPhysicalLayerGridConnect
 from canbus.canlink import CanLink
 from openlcb.nodeid import NodeID
-from openlcb.datagramservice import (
-    # DatagramWriteMemo,
-    # DatagramReadMemo,
-    DatagramService,
-)
-from openlcb.memoryservice import (
-    # MemoryReadMemo,
-    # MemoryWriteMemo,
-    MemoryService,
-)
+from openlcb.datagramservice import DatagramService
+from openlcb.memoryservice import MemoryService
+
 from openlcb.localnodeprocessor import LocalNodeProcessor
 from openlcb.pip import PIP
 from openlcb.snip import SNIP

--- a/example_remote_nodes.py
+++ b/example_remote_nodes.py
@@ -1,0 +1,181 @@
+'''
+Development demo of a testing skeleton.
+This uses a CAN link layer to gather remote node info
+
+Usage:
+python3.10 example_pip_test.py [host|host:port]
+
+Options:
+host|host:port            (optional) Set the address (or using a colon,
+                          the address and port). Defaults to a hard-coded test
+                          address and port.
+'''
+
+from canbus.canphysicallayergridconnect import CanPhysicalLayerGridConnect
+from canbus.canframe import CanFrame
+from canbus.canlink import CanLink
+from canbus.controlframe import ControlFrame
+from canbus.tcpsocket import TcpSocket
+
+from openlcb.node import Node
+from openlcb.nodeid import NodeID
+from openlcb.message import Message
+from openlcb.mti import MTI
+from openlcb.localnodeprocessor import LocalNodeProcessor
+from openlcb.pip import PIP
+from openlcb.remotenodeprocessor import RemoteNodeProcessor
+from openlcb.remotenodestore import RemoteNodeStore
+from openlcb.snip import SNIP
+
+from queue import Queue
+from queue import Empty
+
+# specify default connection information
+host = "192.168.16.212"
+port = 12021
+localNodeID = "05.01.01.01.03.01"
+trace = False
+timeout = 0.5
+
+# region same code as other examples
+
+def usage():
+    print(__doc__, file=sys.stderr)
+
+if __name__ == "__main__":
+    # global host  # only necessary if this is moved to a main/other function
+    import sys
+    if len(sys.argv) == 2:
+        host = sys.argv[1]
+        parts = host.split(":")
+        if len(parts) == 2:
+            host = parts[0]
+            try:
+                port = int(parts[1])
+            except ValueError:
+                usage()
+                print("Error: Port {} is not an integer.".format(parts[1]),
+                      file=sys.stderr)
+                sys.exit(1)
+        elif len(parts) > 2:
+            usage()
+            print("Error: blank, address or address:port format was expected.")
+            sys.exit(1)
+    elif len(sys.argv) > 2:
+        usage()
+        print("Error: blank, address or address:port format was expected.")
+        sys.exit(1)
+
+# endregion same code as other examples
+
+s = TcpSocket()
+s.connect(host, port)
+
+
+if trace :
+    print("RR, SR are raw socket interface receive and send; RL, SL are link (frame) interface")
+
+def sendToSocket(string) :
+    if trace : print("   SR: "+string)
+    s.send(string)
+
+def receiveFrame(frame) : 
+    if trace: print("RL: "+str(frame) )
+ 
+canPhysicalLayerGridConnect = CanPhysicalLayerGridConnect(sendToSocket)
+canPhysicalLayerGridConnect.registerFrameReceivedListener(receiveFrame)
+
+def printMessage(msg):
+    if trace: print("RM: {} from {}".format(msg, msg.source))
+    readQueue.put(msg)
+
+canLink = CanLink(NodeID(localNodeID))
+canLink.linkPhysicalLayer(canPhysicalLayerGridConnect)
+canLink.registerMessageReceivedListener(printMessage)
+
+# create a node and connect it update
+# This is a very minimal node, which just takes part in the low-level common
+# protocols
+localNode = Node(
+    NodeID(localNodeID),
+    SNIP("PythonOlcbNode", "example_node_implementation",
+         "0.1", "0.2", "User Name Here", "User Description Here"),
+    set([PIP.SIMPLE_NODE_IDENTIFICATION_PROTOCOL, PIP.DATAGRAM_PROTOCOL])
+)
+
+localNodeProcessor = LocalNodeProcessor(canLink, localNode)
+canLink.registerMessageReceivedListener(localNodeProcessor.process)
+
+# arrange for remote nodes to be tracked
+remoteNodeStore = RemoteNodeStore(NodeID(localNodeID))
+remoteNodeProcessor = RemoteNodeProcessor(canLink)
+remoteNodeStore.processors = [remoteNodeProcessor]
+canLink.registerMessageReceivedListener(remoteNodeStore.processMessageFromLinkLayer)
+
+
+readQueue = Queue()
+
+# put the read on a separate thread
+def receiveLoop() :
+    # bring the CAN level up
+    if trace : print("      SL : link up")
+    canPhysicalLayerGridConnect.physicalLayerUp()
+    while True:
+        input = s.receive()
+        if trace : print("   RR: "+input)
+        # pass to link processor
+        canPhysicalLayerGridConnect.receiveString(input)
+import threading
+thread = threading.Thread(daemon=True, target=receiveLoop)
+
+# define a routine for checking tests
+def result(arg1, arg2=None, arg3=None, result=True) :
+    # returns True if OK, False if failed
+    # If arg1 and arg2 provided
+    #   compare those, and fail if not equal; arg3 is then message
+    # If only arg1, report it and return result for fail value
+    if arg2 is not None :
+        if arg1 == arg2 :
+            # OK
+            print(arg1)
+            return True
+        else :
+            print("{} does not equal {}, FAIL".format(arg1, arg2))
+            return False
+    else:
+        print(arg1)
+        return result
+
+# start the process
+thread.start()
+
+
+# pull the received messages
+while True :
+    try :
+        received = readQueue.get(True, timeout)
+        if trace : print("received: ", received)
+    except Empty:
+         break
+
+# send an VerifyNodes message to provoke response
+print("\nSend Verify NodeID Number Global\n")
+message = Message(MTI.Verify_NodeID_Number_Global, NodeID(localNodeID), None)
+if trace : print("SM: {}".format(message))
+canLink.sendMessage(message)
+
+# pull the received messages
+while True :
+    try :
+        received = readQueue.get(True, timeout)
+        if trace : print("received: ", received)
+    except Empty:
+         break
+
+# print the resulting node store contents
+print("\nDiscovered nodes:")
+
+for node in remoteNodeStore.asArray() :
+    print(node, node.snip.manufacturerName, "/", node.snip.userProvidedNodeName)
+
+# this ends here, which takes the local node offline

--- a/openlcb/localeventstore.py
+++ b/openlcb/localeventstore.py
@@ -1,0 +1,22 @@
+
+class LocalEventStore :
+    '''
+    Store node-specific Event information
+    '''
+
+    def __init__(self) :
+        self.eventsConsumed=set(())
+        self.eventsProduced=set(())
+        
+    def consumes(self, id) :
+        self.eventsConsumed.add(id)
+    
+    def isConsumed(self, id) :
+        return id in self.eventsConsumed
+    
+    def produces(self, id) :
+        self.eventsProduced.add(id)
+    
+    def isProduced(self, id) :
+        return id in self.eventsProduced
+

--- a/openlcb/node.py
+++ b/openlcb/node.py
@@ -18,10 +18,12 @@ from openlcb.snip import SNIP
 from openlcb.localeventstore import LocalEventStore
 
 class Node:
-    def __init__(self, nodeID, snip=SNIP(), pipSet=set([])):
+    def __init__(self, nodeID, snip=None, pipSet=None):
         self.id = nodeID
         self.snip = snip
+        if snip is None : self.snip = SNIP()
         self.pipSet = pipSet
+        if pipSet is None : self.pipSet = set([])
         self.state = Node.State.Uninitialized
         self.events = LocalEventStore()
 

--- a/openlcb/node.py
+++ b/openlcb/node.py
@@ -15,7 +15,7 @@ node elsewhere" a.k.a an image node.
 
 from enum import Enum
 from openlcb.snip import SNIP
-
+from openlcb.localeventstore import LocalEventStore
 
 class Node:
     def __init__(self, nodeID, snip=SNIP(), pipSet=set([])):
@@ -23,7 +23,7 @@ class Node:
         self.snip = snip
         self.pipSet = pipSet
         self.state = Node.State.Uninitialized
-        self.events = None
+        self.events = LocalEventStore()
 
     def __str__(self):
         return "Node ("+str(self.id)+")"

--- a/openlcb/nodestore.py
+++ b/openlcb/nodestore.py
@@ -47,7 +47,7 @@ class NodeStore :
     
     # Process a message across all nodes
     def invokeProcessorsOnNodes(self, message) :
-        publish = false  # has any processor returned True?
+        publish = False  # has any processor returned True?
         for processor in self.processors :
             for node in self.byIdMap.values() :
                 publish = processor.process(message, node) or publish # always invoke Processsor on node first

--- a/openlcb/nodestore.py
+++ b/openlcb/nodestore.py
@@ -1,0 +1,55 @@
+from openlcb.nodeid import NodeID
+
+class NodeStore :
+    '''
+    Store the available Nodes and provide multiple means of retrieval.
+
+    Storage and indexing methods are an internal detail.
+    You can't remove a node; once we know about it, we know about it.
+    '''
+    
+    def __init__(self) :
+        self.byIdMap = {}
+        self.nodes = []
+        self.processors = []
+            
+    # Store a new node or replace an existing stored node
+    # - Parameter node: new Node content
+    def store(self, node) :
+        self.byIdMap[node.id] = node
+        self.nodes.append(node)
+
+        # sort by SNIP user name (ascending, blanks at front)
+        # This can be too early, when node created but no SNIP yet, so also sort before use in View
+        self.nodes.sort( key=lambda x: x.snip.userProvidedNodeName, reverse=True)
+        
+    def isPresent(self, nodeID ) :
+        return self.byIdMap.get(nodeID) is not None
+    
+    def asArray(self) :
+        return [self.byIdMap[i] for i in self.byIdMap]
+    
+    # Retrieve a Node's content from the store
+    # - Parameter is either
+    #     userProvidedDescription: string to match SNIP content
+    #     nodeID: for direct lookup
+    # - Returns: None if the there's no match
+    def lookup(self, parm) :
+        if isinstance(parm, NodeID) : 
+            if not parm in self.byIdMap :
+                self.byIdMap[parm] = None
+            return self.byIdMap[parm]
+        # assume parm is string
+        for node in self.byIdMap.values() :
+            if (node.snip.userProvidedDescription == parm) :
+                return node
+        return None
+    
+    # Process a message across all nodes
+    def invokeProcessorsOnNodes(self, message) :
+        publish = false  # has any processor returned True?
+        for processor in self.processors :
+            for node in self.byIdMap.values() :
+                publish = processor.process(message, node) or publish # always invoke Processsor on node first
+        return publish
+

--- a/openlcb/pip.py
+++ b/openlcb/pip.py
@@ -43,7 +43,7 @@ class PIP(Enum):
         retval = []
         for pip in PIP.list():
             if (pip.value & contents == pip.value):
-                retval.append(pip.name)
+                retval.append(pip.name.replace("_", " ").title())
         return retval
 
     # return an array of strings for all values included in a collection

--- a/openlcb/remotenodeprocessor.py
+++ b/openlcb/remotenodeprocessor.py
@@ -111,7 +111,6 @@ class RemoteNodeProcessor(Processor) :
             if len(message.data) > 2 :
                 node.snip.addData(message.data)
                 node.snip.updateStringsFromSnipData()
-                # logger.trace("SNIP data added to \(node, privacy: .public)")
 
     def producedEventIndicated(self, message, node) :
         if self.checkSourceID(message, node) : # produced by this node?

--- a/openlcb/remotenodeprocessor.py
+++ b/openlcb/remotenodeprocessor.py
@@ -1,0 +1,128 @@
+
+from openlcb.eventid import EventID
+from openlcb.node import Node
+from openlcb.nodeid import NodeID
+from openlcb.message import Message
+from openlcb.mti import MTI
+from openlcb.processor import Processor
+from openlcb.pip import PIP
+from openlcb.snip import SNIP
+
+class RemoteNodeProcessor(Processor) :
+    '''
+    'Handle incoming messages for a remote node, AKA an image node, representing some
+    physical node out on the layout.
+    
+    Tracks node status, PIP and SNIP information, but deliberately does not 
+    track memory (config, CDI) contents due to size.
+    '''
+
+    def __init__(self, linkLayer=None) :
+        self.linkLayer = linkLayer
+    
+    def process(self, message, node) :
+        # Do a fast drop of messages not to us, from us, or global - note linkLayer up/down are marked as global
+        if not ( message.mti.isGlobal()
+                or self.checkSourceID(message, node)
+                or self.checkDestID(message, node) ) : 
+            return False
+        
+        # if you see anything at all from us, must be in Initialized state
+        if self.checkSourceID(message, node) :  # Sent by node we're processing?
+            node.state = Node.State.Initialized # in case we came late to the party, must be in Initialized state
+        
+        # specific message handling
+        match message.mti :
+            case MTI.Initialization_Complete | MTI.Initialization_Complete_Simple :
+                self.initializationComplete(message, node)
+                return True
+            case MTI.Protocol_Support_Reply :
+                self.protocolSupportReply(message, node)
+                return True
+            case MTI.Link_Layer_Up :
+                self.linkUpMessage(message, node)
+            case MTI.Link_Layer_Down :
+                self.linkDownMessage(message, node)
+            case MTI.Simple_Node_Ident_Info_Request :
+                self.simpleNodeIdentInfoRequest(message, node)
+            case MTI.Simple_Node_Ident_Info_Reply :
+                self.simpleNodeIdentInfoReply(message, node)
+                return True
+            case MTI.Producer_Identified_Active | MTI.Producer_Identified_Inactive | MTI.Producer_Identified_Unknown | MTI.Producer_Consumer_Event_Report :
+                self.producedEventIndicated(message, node)
+                return True
+            case MTI.Consumer_Identified_Active | MTI.Consumer_Identified_Inactive | MTI.Consumer_Identified_Unknown :
+                self.consumedEventIndicated(message, node)
+                return True
+            case MTI.New_Node_Seen :
+                self.newNodeSeen(message, node)
+                return True
+            case _ :
+                # we ignore others
+                return False
+        return False
+    
+    def initializationComplete(self, message, node) :
+        if self.checkSourceID(message, node) :  # Send by us?
+            node.state = Node.State.Initialized
+            # clear out PIP, SNIP caches - may have changed while node was offline
+            node.pipSet = set(())
+            node.snip = SNIP()
+    
+    def linkUpMessage(self, message, node) :
+        # affects everybody
+        node.state = Node.State.Uninitialized
+        # don't clear out PIP, SNIP caches, they're probably still good
+    
+    def linkDownMessage(self, message, node) :
+        # affects everybody
+        node.state = Node.State.Uninitialized
+        # don't clear out PIP, SNIP caches, they're probably still good
+    
+    def newNodeSeen(self, message, node) :
+        # send pip and snip requests for info from the new node
+        pip = Message(MTI.Protocol_Support_Inquiry, self.linkLayer.localNodeID, node.id, [])
+        self.linkLayer.sendMessage(pip)
+        # We request SNIP data on startup so that we can display node names.  Can consider deferring this is it's a issue on big networks
+        snip = Message(MTI.Simple_Node_Ident_Info_Request, self.linkLayer.localNodeID, node.id, [])
+        self.linkLayer.sendMessage(snip)
+        # we request produced and consumed event IDs
+        eventReq = Message(MTI.Identify_Events_Addressed, self.linkLayer.localNodeID, node.id, [])
+        self.linkLayer.sendMessage(eventReq)
+    
+    def protocolSupportReply(self, message, node) :
+        if self.checkSourceID(message, node) : # sent by us?
+            part0 = ((message.data[0]) << 24) if (len(message.data) > 0) else 0
+            part1 = ((message.data[1]) << 16) if (len(message.data) > 1) else 0
+            part2 = ((message.data[2]) <<  8) if (len(message.data) > 2) else 0
+            part3 = ((message.data[3])      ) if (len(message.data) > 3) else 0
+
+            content =  part0|part1|part2|part3
+            node.pipSet = PIP.setContentsFromInt(content)
+    
+    def simpleNodeIdentInfoRequest(self, message, node) :
+        if self.checkDestID(message, node) : # sent by us? - overlapping SNIP activity is otherwise confusing
+            # clear SNIP in the node to start accumulating
+            node.snip = SNIP()
+
+    def simpleNodeIdentInfoReply(self, message, node) :
+        if self.checkSourceID(message, node) : # sent by this node? - overlapping SNIP activity is otherwise confusing
+            # accumulate data in the node
+            if len(message.data) > 2 :
+                node.snip.addData(message.data)
+                node.snip.updateStringsFromSnipData()
+                # logger.trace("SNIP data added to \(node, privacy: .public)")
+
+    def producedEventIndicated(self, message, node) :
+        if self.checkSourceID(message, node) : # produced by this node?
+            # make an event id from the data
+            eventID = EventID(message.data)
+            # register it
+            node.events.produces(eventID)
+    
+    def consumedEventIndicated(self, message, node) :
+        if self.checkSourceID(message, node) : # consumed by this node?
+            # make an event id from the data
+            eventID = EventID(message.data)
+            # register it
+            node.events.consumes(eventID)

--- a/openlcb/remotenodestore.py
+++ b/openlcb/remotenodestore.py
@@ -1,0 +1,41 @@
+from openlcb.nodestore import NodeStore
+
+class RemoteNodeStore(NodeStore) :
+    '''
+       Accumulates Nodes that it sees requested, unless they're already in a given local NodeStore
+    ''' 
+    
+    def __init__(self, localNodeID) :
+        self.localNodeID = localNodeID
+        NodeStore.__init__(self)
+
+    def description(self) : return  "RemoteNodeStore w {}".format(nodes.count)
+
+    # return True if the message is to a new node, so that createNewRemoteNode should be called.
+    def checkForNewNode(self, message) :
+        nodeID = message.source
+        if nodeID == localNodeID :
+            # present in other store, skip
+            return False
+        # NodeID(0) is a special case, used for e.g. linkUp, linkDown; don't store
+        if (nodeID == NodeID(0)) :
+            return False
+        # make sure source node is in store if it needs to be
+        if lookup(message.source) is not None :
+            return False
+        return True
+    
+    # a new node was found by checkForNewNode, so this
+    # mutates the store to add this.  This should only be called
+    # if checkForNewNode is true to avoid excess publishing!
+    def createNewRemoteNode(self, message) :
+        # need to create the node and process it's New_Node_Seen
+        nodeID = message.source
+        node = Node(nodeID)
+        
+        store(node)
+        # All nodes process a notification that there's a new node
+        newNodeMessage = Message(MTI.New_Node_Seen, nodeID, None)
+        for processor in processors :
+            processor.process(newNodeMessage, node)
+

--- a/openlcb/snip.py
+++ b/openlcb/snip.py
@@ -1,19 +1,15 @@
-'''
-based on SNIP.swift
-
-Created by Bob Jacobsen on 6/1/22.
-
-Holds the Simple Node Information Protocol values or blank strings.
-
-Provides support for loading via short or long messages. A SNIP is write-once;
-when the underlying connection resets, a new SNIP struct should be installed in
-the node.
-'''
 
 import logging
 
-
 class SNIP:
+    '''
+    Holds the Simple Node Information Protocol values or blank strings.
+
+    Provides support for loading via short or long messages. A SNIP is write-once;
+    when the underlying connection resets, a new SNIP struct should be installed in
+    the node.
+    '''
+    
     def __init__(self, mfgName="",
                  model="",
                  hVersion="",

--- a/tcplink/tcplink.py
+++ b/tcplink/tcplink.py
@@ -89,7 +89,7 @@ class TcpLink(LinkLayer):
         key = gatewayNodeID   # do we need to have the capture time in here?
         if (flags & 0x00C0) == 0x040 : # first
             # check for error 
-            if self.accumulatedParts.get(key) != None :
+            if self.accumulatedParts.get(key) is not None :
                 # this was a first, but shouldn't have been
                 logging.warn("Found a first part from [] while already accumulating"
                                 .format(nodeId))

--- a/test_all.py
+++ b/test_all.py
@@ -30,9 +30,14 @@ from tests.test_memoryservice import *
 from tests.test_snip import *
 from tests.test_pip import *
 
-from tests.test_processor import *
+from tests.test_nodestore import *
+from tests.test_remotenodestore import *
 
+from tests.test_localeventstore import *
+
+from tests.test_processor import *
 from tests.test_localnodeprocessor import *
+from tests.test_remotenodeprocessor import *
 
 
 if __name__ == '__main__':

--- a/tests/test_localeventstore.py
+++ b/tests/test_localeventstore.py
@@ -1,0 +1,24 @@
+import unittest
+
+from openlcb.localeventstore import LocalEventStore
+
+from openlcb.eventid import EventID
+
+class TestLocalEventStorelass(unittest.TestCase):
+
+    def testConsumes(self) :
+        store = LocalEventStore()
+        
+        store.consumes(EventID(2))
+        self.assertTrue(store.isConsumed(EventID(2)))
+        self.assertFalse(store.isConsumed(EventID(3)))
+
+    def testProduces(self) :
+        store = LocalEventStore()
+        
+        store.produces(EventID(4))
+        self.assertTrue(store.isProduced(EventID(4)))
+        self.assertFalse(store.isProduced(EventID(5)))
+        
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_nodestore.py
+++ b/tests/test_nodestore.py
@@ -1,0 +1,34 @@
+import unittest
+
+from openlcb.nodestore import NodeStore
+
+from openlcb.node import Node
+from openlcb.nodeid import NodeID
+
+class TestNodeStoreClass(unittest.TestCase):
+
+    def testIsPresent(self) :
+        dut = NodeStore()
+        
+        node = Node(NodeID(120))
+        dut.store(node)
+
+        self.assertEqual(dut.isPresent(NodeID(120)), True, "is present")
+
+        self.assertEqual(dut.isPresent(NodeID(123)), False, "is present")
+
+    def testIsPresent(self) :
+        dut = NodeStore()
+        
+        node1 = Node(NodeID(120))
+        dut.store(node1)
+
+        node2 = Node(NodeID(240))
+        dut.store(node2)
+
+        self.assertEqual(dut.asArray(), [node1, node2], "as array")
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_pip.py
+++ b/tests/test_pip.py
@@ -31,9 +31,18 @@ class TestPipClass(unittest.TestCase):
                 PIP.SIMPLE_NODE_IDENTIFICATION_PROTOCOL])
         )
 
-    def testContentsNameUInt(self):
+    def testContainsFromRaw4(self):
+        array = [0x10, 0x10, 0, 0]
+        result = PIP.setContentsFromList(array)
+        self.assertEqual(
+            result,
+            set([PIP.MEMORY_CONFIGURATION_PROTOCOL,
+                PIP.SIMPLE_NODE_IDENTIFICATION_PROTOCOL])
+        )
+
+    def testContentsNameUInt1(self):
         result = PIP.contentsNamesFromInt(0x10_00_00)
-        self.assertEqual(result, ["SIMPLE_NODE_IDENTIFICATION_PROTOCOL"])
+        self.assertEqual(result, ["Simple Node Identification Protocol"])
 
     def testContentsNameUSet(self):
         input = set([PIP.SIMPLE_NODE_IDENTIFICATION_PROTOCOL])

--- a/tests/test_remotenodeprocessor.py
+++ b/tests/test_remotenodeprocessor.py
@@ -1,0 +1,149 @@
+import unittest
+
+from openlcb.remotenodeprocessor import RemoteNodeProcessor
+
+from canbus.canlink import CanLink
+
+from openlcb.eventid import EventID
+from openlcb.node import Node
+from openlcb.nodeid import NodeID
+from openlcb.message import Message
+from openlcb.mti import MTI
+from openlcb.pip import PIP
+
+
+class TesRemoteNodeProcessorClass(unittest.TestCase):
+
+    def setUp(self) :
+        self.node21 = Node(NodeID(21))
+        self.processor = RemoteNodeProcessor(CanLink(NodeID(100)))
+
+
+    def testInitializationComplete(self) :
+        # not related to node
+        msg1 = Message(MTI.Initialization_Complete, NodeID(13), None)
+        self.assertEqual(self.node21.state, Node.State.Uninitialized, "node state starts uninitialized")
+        self.processor.process(msg1, self.node21)
+        self.assertEqual(self.node21.state, Node.State.Uninitialized, "node state stays uninitialized")
+
+        # send by node
+        msg2 = Message(MTI.Initialization_Complete, NodeID(21), None)
+        self.assertEqual(self.node21.state, Node.State.Uninitialized, "node state starts uninitialized")
+        self.processor.process(msg2, self.node21)
+        self.assertEqual(self.node21.state, Node.State.Initialized, "node state goes initialized")
+        
+
+
+    def testPipReplyFull(self) :
+        msg1 = Message(MTI.Protocol_Support_Reply, NodeID(12), NodeID(13), [0x10, 0x10, 0x00, 0x00])
+        self.processor.process(msg1, self.node21)
+        self.assertEqual(self.node21.pipSet, set(()) );
+
+        msg2 = Message(MTI.Protocol_Support_Reply, NodeID(21), NodeID(12), [0x10, 0x10, 0x00, 0x00])
+        self.processor.process(msg2, self.node21)
+        self.assertEqual(self.node21.pipSet, set([PIP.MEMORY_CONFIGURATION_PROTOCOL, PIP.SIMPLE_NODE_IDENTIFICATION_PROTOCOL]))
+
+
+    def testPipReply2(self) :
+        msg1 = Message(MTI.Protocol_Support_Reply, NodeID(12), NodeID(13), [0x10, 0x10])
+        self.processor.process(msg1, self.node21)
+        self.assertEqual(self.node21.pipSet, set(()) )
+
+        msg2 = Message(MTI.Protocol_Support_Reply, NodeID(21), NodeID(12), [0x10, 0x10])
+        self.processor.process(msg2, self.node21)
+        self.assertEqual(self.node21.pipSet, set([PIP.MEMORY_CONFIGURATION_PROTOCOL, PIP.SIMPLE_NODE_IDENTIFICATION_PROTOCOL]))
+
+
+    def testPipReplyEmpty(self) :
+        msg = Message(MTI.Protocol_Support_Reply, NodeID(12), NodeID(13))
+        self.processor.process(msg, self.node21)
+        self.assertEqual(self.node21.pipSet, set(()))
+
+
+    def testLinkDown(self) :
+        self.node21.pipSet = set([PIP.EVENT_EXCHANGE_PROTOCOL])
+        self.node21.state = Node.State.Initialized
+        msg = Message(MTI.Link_Layer_Down, NodeID(0), NodeID(0))
+        self.processor.process(msg, self.node21)
+        self.assertEqual(self.node21.pipSet, set([PIP.EVENT_EXCHANGE_PROTOCOL]))
+        self.assertEqual(self.node21.state, Node.State.Uninitialized)
+
+
+    def testLinkUp(self) :
+        self.node21.pipSet = set([PIP.EVENT_EXCHANGE_PROTOCOL])
+        self.node21.state = Node.State.Initialized
+        msg = Message(MTI.Link_Layer_Up, NodeID(0), NodeID(0))
+        self.processor.process(msg, self.node21)
+        self.assertEqual(self.node21.pipSet, set([PIP.EVENT_EXCHANGE_PROTOCOL]))
+        self.assertEqual(self.node21.state, Node.State.Uninitialized)
+
+
+    def testUndefinedType(self) :
+        msg = Message(MTI.Unknown, NodeID(12), NodeID(13)) # neither to nor from us
+        # nothing but logging happens on an unknown type
+        self.processor.process(msg, self.node21)
+        
+        msg = Message(MTI.Unknown, NodeID(12), NodeID(21)) # to us
+        # nothing but logging happens on an unknown type
+        self.processor.process(msg, self.node21)
+
+    
+    def testSnipHandling(self) :
+        self.node21.snip.manufacturerName = "name present"
+        
+        # message not to us
+        msg = Message(MTI.Simple_Node_Ident_Info_Request, NodeID(12), NodeID(13))
+        self.processor.process(msg, self.node21)
+        
+        # should not have cleared SNIP and cache
+        self.assertEqual(self.node21.snip.manufacturerName, "name present")
+        
+        # message to us
+        msg = Message(MTI.Simple_Node_Ident_Info_Request, NodeID(12), NodeID(21))
+        self.processor.process(msg, self.node21)
+        
+        # should have cleared SNIP and cache
+        self.assertEqual(self.node21.snip.manufacturerName, "")
+        
+         # add some data
+        msg = Message(MTI.Simple_Node_Ident_Info_Reply, NodeID(21), NodeID(12), [4,0x31,0x32,0,0,0])
+        self.processor.process(msg, self.node21)
+
+        self.assertEqual(self.node21.snip.manufacturerName, "12")
+
+   
+    def testProducerIdentified(self) :
+        self.node21.state = Node.State.Initialized
+        msg = Message(MTI.Producer_Identified_Active, self.node21.id, None, [1,2,3,4,5,6,7,8])
+        self.processor.process(msg, self.node21)
+        self.assertTrue(self.node21.events.isProduced(EventID(0x01_02_03_04_05_06_07_08)))
+
+
+    def testProducerIdentifiedDifferentNode(self) :
+        self.node21.state = Node.State.Initialized
+        msg = Message(MTI.Producer_Identified_Active, NodeID(1), None, [1,2,3,4,5,6,7,8])
+        self.processor.process(msg, self.node21)
+        self.assertFalse(self.node21.events.isProduced(EventID(0x01_02_03_04_05_06_07_08)))
+
+
+    def testConsumerIdentified(self) :
+        self.node21.state = Node.State.Initialized
+        msg = Message(MTI.Consumer_Identified_Active, self.node21.id, None, [1,2,3,4,5,6,7,8])
+        self.processor.process(msg, self.node21)
+        self.assertTrue(self.node21.events.isConsumed(EventID(0x01_02_03_04_05_06_07_08)))
+
+
+    def testConsumerIdentifiedDifferentNode(self) :
+        self.node21.state = Node.State.Initialized
+        msg = Message(MTI.Consumer_Identified_Active, NodeID(1), None, [1,2,3,4,5,6,7,8])
+        self.processor.process(msg, self.node21)
+        self.assertFalse(self.node21.events.isConsumed(EventID(0x01_02_03_04_05_06_07_08)))
+
+    def testNewNodeSeen(self) :
+        self.node21.state = Node.State.Initialized
+        msg = Message(MTI.New_Node_Seen, NodeID(21), [])
+        self.processor.process(msg, self.node21)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_remotenodestore.py
+++ b/tests/test_remotenodestore.py
@@ -1,0 +1,75 @@
+import unittest
+
+from openlcb.node import Node
+from openlcb.nodeid import NodeID
+from openlcb.remotenodestore import RemoteNodeStore
+
+class TestRemoteNodeStoreClass(unittest.TestCase) :
+
+    def testSimpleLoadStore(self) :
+        store = RemoteNodeStore(NodeID(1))
+        
+        n12 = Node(NodeID(12))
+        
+        store.store(n12)
+        store.store(Node(NodeID(13)))
+        
+        self.assertEqual(store.lookup(NodeID(12)), n12, "store then lookup OK")
+
+
+    def testRequestCreates(self) :
+        nodeStore = RemoteNodeStore(NodeID(1))
+        
+        # try a load
+        temp = nodeStore.lookup(NodeID(12))
+        
+        self.assertEqual(temp, None, "lookup returns None if node not present")
+
+
+    def testAccessThroughLoadStoreByID(self) :
+        nodeStore = RemoteNodeStore(NodeID(1))
+        
+        nid12 = NodeID(12)
+        nid13 = NodeID(13)
+
+        n12 = Node(nid12)
+        n13 = Node(nid13)
+
+        nodeStore.store(n12)
+        nodeStore.store(n13)
+        
+        # test ability to modify state
+        n12.state = Node.State.Initialized
+        self.assertEqual(n12.state, Node.State.Initialized, "local modification OK")
+        self.assertEqual(nodeStore.lookup(nid12).state, Node.State.Initialized, "original in store modified")
+        
+        # lookup non-existing node returns None
+        self.assertEqual(nodeStore.lookup(NodeID(21)), None, "None on no match in store")
+        
+        temp = nodeStore.lookup(nid13)
+        temp.state = Node.State.Uninitialized
+        nodeStore.store(temp)
+        self.assertEqual(nodeStore.lookup(nid13).state, Node.State.Uninitialized,
+                            "original in store modified by replacement")
+
+
+
+    def testALocalStoreVeto(self) :
+        nid12 = NodeID(12)
+        n12 = Node(nid12)
+        
+        nid13 = NodeID(13)
+ 
+        store = RemoteNodeStore(nid13)
+
+        store.store(n12)
+        
+        # lookup non-existing node doesn't create it if in local store
+        self.assertEqual(store.lookup(nid13), None, "don't create if in local store")
+        
+    def testCustomStringConvertible(self) : # existence test, don't check content which can change
+        store = RemoteNodeStore(NodeID(13))
+        store.description
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds support for accessing remote nodes, including getting PIP, SNIP and Event consumer/producer information from them at startup.  `example_remote_nodes.py` demonstrates that.