### PR TITLE
Python 3.8 compatibility

### DIFF
--- a/openlcb/canbus/canlink.py
+++ b/openlcb/canbus/canlink.py
@@ -52,34 +52,41 @@ class CanLink(LinkLayer):
         Permitted = 3
 
     def receiveListener(self, frame):  # CanFrame
-        match self.decodeControlFrameFormat(frame):
-            case ControlFrame.LinkUp:
-                self.handleReceivedLinkUp(frame)
-            case ControlFrame.LinkRestarted:
-                self.handleReceivedLinkRestarted(frame)
-            case ControlFrame.LinkCollision | ControlFrame.LinkError:
-                logging.warning("Unexpected error report {:08X}"
-                                "".format(frame.header))
-            case ControlFrame.LinkDown:
-                self.handleReceivedLinkDown(frame)
-            case ControlFrame.CID:
-                self.handleReceivedCID(frame)
-            case ControlFrame.RID:
-                self.handleReceivedRID(frame)
-            case ControlFrame.AMD:
-                self.handleReceivedAMD(frame)
-            case ControlFrame.AME:
-                self.handleReceivedAME(frame)
-            case ControlFrame.AMR:
-                self.handleReceivedAMR(frame)
-            case (ControlFrame.EIR0 | ControlFrame.EIR1 | ControlFrame.EIR2,
-                  ControlFrame.EIR3):
-                pass   # ignored upon receipt
-            case ControlFrame.Data:
-                self.handleReceivedData(frame)
-            case ControlFrame.UnknownFormat:
-                logging.warning("Unexpected CAN header 0x{:08X}"
-                                "".format(frame.header))
+
+        if self.decodeControlFrameFormat(frame) == ControlFrame.LinkUp:
+            self.handleReceivedLinkUp(frame)
+        elif self.decodeControlFrameFormat(frame) == ControlFrame.LinkRestarted:
+            self.handleReceivedLinkRestarted(frame)
+        elif self.decodeControlFrameFormat(frame) in (ControlFrame.LinkCollision,
+                                                      ControlFrame.LinkError):
+            logging.warning("Unexpected error report {:08X}"
+                            "".format(frame.header))
+        elif self.decodeControlFrameFormat(frame) == ControlFrame.LinkDown:
+            self.handleReceivedLinkDown(frame)
+        elif self.decodeControlFrameFormat(frame) == ControlFrame.CID:
+            self.handleReceivedCID(frame)
+        elif self.decodeControlFrameFormat(frame) == ControlFrame.RID:
+            self.handleReceivedRID(frame)
+        elif self.decodeControlFrameFormat(frame) == ControlFrame.AMD:
+            self.handleReceivedAMD(frame)
+        elif self.decodeControlFrameFormat(frame) == ControlFrame.AME:
+            self.handleReceivedAME(frame)
+        elif self.decodeControlFrameFormat(frame) == ControlFrame.AMR:
+            self.handleReceivedAMR(frame)
+        elif self.decodeControlFrameFormat(frame) in (ControlFrame.EIR0,
+                                                      ControlFrame.EIR1,
+                                                      ControlFrame.EIR2,
+                                                      ControlFrame.EIR3):
+            pass   # ignored upon receipt
+        elif self.decodeControlFrameFormat(frame) == ControlFrame.Data:
+            self.handleReceivedData(frame)
+        elif (self.decodeControlFrameFormat(frame)
+              == ControlFrame.UnknownFormat):
+            logging.warning("Unexpected CAN header 0x{:08X}"
+                            "".format(frame.header))
+        else:
+            logging.warning("Invalid control frame format 0x{:08X}"
+                            "".format(self.decodeControlFrameFormat(frame)))
 
     def handleReceivedLinkUp(self, frame):  # CanFrame
         """Link started, update state, start process to create alias.

--- a/openlcb/datagramservice.py
+++ b/openlcb/datagramservice.py
@@ -170,17 +170,16 @@ class DatagramService:
                 or self.checkDestID(message, self.linkLayer.localNodeID)):
             return False
 
-        match message.mti:
-            case MTI.Datagram:
-                self.handleDatagram(message)
-            case MTI.Datagram_Rejected:
-                self.handleDatagramRejected(message)
-            case MTI.Datagram_Received_OK:
-                self.handleDatagramReceivedOK(message)
-            case MTI.Link_Layer_Quiesce:
-                self.handleLinkQuiesce(message)
-            case MTI.Link_Layer_Restarted:
-                self.handleLinkRestarted(message)
+        if message.mti == MTI.Datagram:
+            self.handleDatagram(message)
+        elif message.mti == MTI.Datagram_Rejected:
+            self.handleDatagramRejected(message)
+        elif message.mti == MTI.Datagram_Received_OK:
+            self.handleDatagramReceivedOK(message)
+        elif message.mti == MTI.Link_Layer_Quiesce:
+            self.handleLinkQuiesce(message)
+        elif message.mti == MTI.Link_Layer_Restarted:
+            self.handleLinkRestarted(message)
         return False
 
     def handleDatagram(self, message):

--- a/openlcb/localnodeprocessor.py
+++ b/openlcb/localnodeprocessor.py
@@ -34,37 +34,38 @@ class LocalNodeProcessor(Processor):
         if not (self.checkDestID(message, node) or message.isGlobal()):
             return False  # not to us
         # specific message handling
-        match message.mti:
-            # NOTE: Python 3.10 "match" uses "|" for logic (not "or").
-            case MTI.Link_Layer_Up:
-                self.linkUpMessage(message, node)
-            case MTI.Link_Layer_Down:
-                self.linkDownMessage(message, node)
-            case MTI.Verify_NodeID_Number_Global:
-                self.verifyNodeIDNumberGlobal(message, node)
-            case MTI.Verify_NodeID_Number_Addressed:
-                self.verifyNodeIDNumberAddressed(message, node)
-            case MTI.Protocol_Support_Inquiry:
-                self.protocolSupportInquiry(message, node)
-            case MTI.Protocol_Support_Reply | MTI.Simple_Node_Ident_Info_Reply:
-                # these are not relevant here
-                pass
-            case MTI.Traction_Control_Command | MTI.Traction_Control_Reply:
-                # these are not relevant here
-                pass
-            case MTI.Datagram | MTI.Datagram_Rejected | MTI.Datagram_Received_OK:
-                # datagrams and datagram replies are handled in the
-                # DatagramService
-                pass
-            case MTI.Simple_Node_Ident_Info_Request:
-                self.simpleNodeIdentInfoRequest(message, node)
-            case MTI.Identify_Events_Addressed:
-                self.identifyEventsAddressed(message, node)
-            case (MTI.Terminate_Due_To_Error
-                  | MTI.Optional_Interaction_Rejected):
-                self.errorMessageReceived(message, node)
-            case _:
-                self.unrecognizedMTI(message, node)
+        if message.mti == MTI.Link_Layer_Up:
+            self.linkUpMessage(message, node)
+        elif message.mti == MTI.Link_Layer_Down:
+            self.linkDownMessage(message, node)
+        elif message.mti == MTI.Verify_NodeID_Number_Global:
+            self.verifyNodeIDNumberGlobal(message, node)
+        elif message.mti == MTI.Verify_NodeID_Number_Addressed:
+            self.verifyNodeIDNumberAddressed(message, node)
+        elif message.mti == MTI.Protocol_Support_Inquiry:
+            self.protocolSupportInquiry(message, node)
+        elif message.mti in (MTI.Protocol_Support_Reply,
+                             MTI.Simple_Node_Ident_Info_Reply):
+            # these are not relevant here
+            pass
+        elif message.mti in (MTI.Traction_Control_Command,
+                             MTI.Traction_Control_Reply):
+            # these are not relevant here
+            pass
+        elif message.mti in (MTI.Datagram, MTI.Datagram_Rejected,
+                             MTI.Datagram_Received_OK):
+            # datagrams and datagram replies are handled in the
+            # DatagramService
+            pass
+        elif message.mti == MTI.Simple_Node_Ident_Info_Request:
+            self.simpleNodeIdentInfoRequest(message, node)
+        elif message.mti == MTI.Identify_Events_Addressed:
+            self.identifyEventsAddressed(message, node)
+        elif message.mti in (MTI.Terminate_Due_To_Error,
+                             MTI.Optional_Interaction_Rejected):
+            self.errorMessageReceived(message, node)
+        else:
+            self.unrecognizedMTI(message, node)
         return False
 
     # private method

--- a/openlcb/snip.py
+++ b/openlcb/snip.py
@@ -42,21 +42,19 @@ class SNIP:
                 byte
         '''
         start = self.findString(n)
-        len = 0
-        # NOTE: Python 3.10 "match" uses "|" for logic (not "or").
-        match n:
-            case 0 | 1:
-                len = 41
-            case 2 | 3:
-                len = 21
-            case 4:
-                len = 63
-            case 5:
-                len = 64
-            case _:
-                logging.error("Unexpected string request: {}".format(n))
-                return ""
-        return self.getString(start, len)
+        length = 0
+        if n in (0, 1):
+            length = 41
+        elif n in (2, 3):
+            length = 21
+        elif n == 4:
+            length = 63
+        elif n == 5:
+            length = 64
+        else:
+            logging.error("Unexpected string request: {}".format(n))
+            return ""
+        return self.getString(start, length)
 
     #  FInd start index of the nth string.
     #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ maintainers = [
   {name = "Bob Jacobsen"}
 ]
 version = "0.0.1"
-requires-python = ">= 3.10"
+requires-python = ">= 3.8"
 # dynamic = ["version"]
 # ^ allows version to be overridden by a git tag using
 #   setuptools_scm, or by a __version__ Python attribute.


### PR DESCRIPTION
This is a redo of the pull request. The previous pull request had 0 commits since I rebased. The commits were stored in this branch:
```
git switch main
git branch -b python-3.8-compat
git cherry-pick 6d6b15f2c3361050a1776d1f14fcca9e7163c577
git cherry-pick 7ed5549b87d83fed5e5a4957d5e400c195b76c25
```
so this one can be used for the PR.

To reiterate https://github.com/bobjacobsen/PythonOlcbNode/pull/23:

Python 3.8 compatibility changes:
- Match statements are changed to `if`-`elif`-`else`
   - `in (some_value, some_other_value)` is used to match against multiple values (instead of match's context-specific parsing of `|` which is used as binary when not in a `match` scope)
- Python version requirement in pyproject is changed from `>= 3.10` to `>= 3.8`
- May work on earlier versions of Python.
- May work on earlier versions of Windows such as Vista (not tested).
  - However, Python 3.7 backport to XP may have "problems with some Internet stuff" (<https://retrosystemsrevival.blogspot.com/2021/01/python-371-for-windows-xp.html>).
