### PR TITLE
Document python 3.8 use; add a serial example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 A Python implementation of [OpenLCB](http://www.openlcb.org)/[LCC](https://www.nmra.org/lcc) based on the [LccTools](https://apps.apple.com/sr/app/lcctools/id1640295587) app's [Swift implementation](https://github.com/bobjacobsen/OpenlcbLibrary) as of January 2024.
 
-Requires Python 3.10 or later.
+Requires Python 3.8 or later.
 
 Windows note: In various instructions in this project's documentation,
-if you are using Windows you must install Python 3.10 or higher from
+if you are using Windows you must install Python 3.8 or higher from
 python.org with the "py" runner and PATH options both enabled during
 install.
-- After that you must replace "python3.10" or "python3" command with
+- After that you must replace "python3.8" or "python3" command with
   "py -3" (or simply "python" if you only have Python 3 and not 2
   installed).
 
@@ -21,7 +21,7 @@ userspace).
 Linux:
 ```
 mkdir -p ~/.virtualenvs
-python3.10 -m venv ~/.virtualenvs/pytest-env
+python3 -m venv ~/.virtualenvs/pytest-env
 source ~/.virtualenvs/pytest-env/bin/activate
 ``` 
 
@@ -54,35 +54,42 @@ If using VSCode (or fully open-source VSCodium):
 ### Testing
 To run the unit test suite:
 ```
-python3.10 -m pip install --user pytest
+python3 -m pip install --user pytest
 # ^ or use a 
-python3.10 -m pytest
+python3 -m pytest
 # or to auto-detect test and run with standard log level:
-# python3.10 -m pytest tests
+# python3 -m pytest tests
 
 # or to use with only unittest not pytest:
-# python3.10 test_all.py
+# python3 test_all.py
 ```
 
 
 #### Examples
 There are examples for using the code at various levels of integration:
 ```
-python3.10 example_string_interface.py
-python3.10 example_frame_interface.py
-python3.10 example_message_interface.py
-python3.10 example_datagram_transfer.py
-python3.10 example_memory_transfer.py
-python3.10 example_node_implementation.py
+python3 example_string_interface.py
+python3 example_frame_interface.py
+python3 example_message_interface.py
+python3 example_datagram_transfer.py
+python3 example_memory_transfer.py
+python3 example_node_implementation.py
 ```
 
 These will require the right host name and port number; and if different Node ID(s) are necessary for your hardware configuration, they would have to be edited manually in the example py file(s) (or parameterized in a program based on the example(s)): See near top of the files, below imports.
 
 You can override the hard-coded IP address and port by passing it as the first argument on the command line. Example:
 ```
-python3.10 example_node_implementation.py 192.168.1.40
-python3.10 example_node_implementation.py 192.168.1.40:12021
+python3 example_node_implementation.py 192.168.1.40
+python3 example_node_implementation.py 192.168.1.40:12021
 ```
 
-For an overview of the structure, see [this diagram](doc/Overview.png) of the example programs.
+There's also a serial-port based example. 
+```
+python3 example_string_serial_interface.py/dev/cu.ProperSerialPort
+```
+This can be compared to the example_string_interface.py to see
+the (small) differences between the serial version and the GridConnect TCP versions.
+
+For an overview of the implementation structure, see [this diagram](doc/Overview.png) of the example programs.
 

--- a/example_remote_nodes.py
+++ b/example_remote_nodes.py
@@ -3,7 +3,7 @@ Development demo of a testing skeleton.
 This uses a CAN link layer to gather remote node info
 
 Usage:
-python3.10 example_pip_test.py [host|host:port]
+python3 example_pip_test.py [host|host:port]
 
 Options:
 host|host:port            (optional) Set the address (or using a colon,

--- a/example_string_serial_interface.py
+++ b/example_string_serial_interface.py
@@ -1,0 +1,65 @@
+'''
+Example of raw socket communications over the physical connection, in this case
+a socket.
+
+Usage:
+python3 example_string_interface.py [host|host:port]
+
+Options:
+host|host:port            (optional) Set the address (or using a colon,
+                          the address and port). Defaults to a hard-coded test
+                          address and port.
+'''
+
+from openlcb.canbus.seriallink import SerialLink
+
+# specify connection information
+device = "/dev/cu.usbmodemCC570001B1"
+
+# region same code as other examples
+
+
+def usage():
+    print(__doc__, file=sys.stderr)
+
+
+if __name__ == "__main__":
+    # global host  # only necessary if this is moved to a main/other function
+    import sys
+    if len(sys.argv) == 2:
+        host = sys.argv[1]
+        parts = host.split(":")
+        if len(parts) == 2:
+            host = parts[0]
+            try:
+                port = int(parts[1])
+            except ValueError:
+                usage()
+                print("Error: Port {} is not an integer.".format(parts[1]),
+                      file=sys.stderr)
+                sys.exit(1)
+        elif len(parts) > 2:
+            usage()
+            print("Error: blank, address or address:port format was expected.")
+            sys.exit(1)
+    elif len(sys.argv) > 2:
+        usage()
+        print("Error: blank, address or address:port format was expected.")
+        sys.exit(1)
+
+# endregion same code as other examples
+
+s = SerialLink()
+s.connect(device)
+
+#######################
+
+# send a AME frame in GridConnect string format with arbitrary source alias to
+# elicit response
+AME = ":X10702001N;"
+s.send(AME)
+print("SR: {}".format(AME.strip()))
+
+# display response - should be RID from node(s)
+while True:  # have to kill this manually
+    print("RR: {}".format(s.receive().strip()))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Topic :: System :: Hardware",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: MIT License",
-  "Programming Language :: Python :: 3.10"
+  "Programming Language :: Python :: 3.8"
 ]
 authors = [
   {name = "Bob Jacobsen"},


### PR DESCRIPTION
This updates the README for Python 3.8 instead of 3.10. Also added an example script that uses a serial port instead of a TCP GridConnect connection.

@Poikilos I didn't update the Python 3.10 reference in the pyproject.toml file.  Should I include that?  Thanks